### PR TITLE
fixed prefer_single_quotes

### DIFF
--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -48,7 +48,7 @@ class Combination extends Equatable {
 
   @override
   String toString() {
-    return "Combination($front-$back)";
+    return 'Combination($front-$back)';
   }
 
   @override
@@ -64,7 +64,7 @@ class Master extends Equatable {
 
   @override
   String toString() {
-    return "Master($id-$fields-$combinations)";
+    return 'Master($id-$fields-$combinations)';
   }
 
   @override
@@ -87,12 +87,7 @@ class Review extends Equatable {
 
 class DRCard extends Equatable {
   const DRCard(
-      {this.master,
-      this.combination,
-      this.front,
-      this.back,
-      this.lastReviewed,
-      this.dueDate});
+      {this.master, this.combination, this.front, this.back, this.lastReviewed, this.dueDate});
 
   final String master;
   final Combination combination;
@@ -106,8 +101,7 @@ class DRCard extends Equatable {
 }
 
 abstract class CardState extends Equatable {
-  const CardState(this.master, this.combination, this.mode, this.lastReviewed,
-      this.interval);
+  const CardState(this.master, this.combination, this.mode, this.lastReviewed, this.interval);
   final String master;
   final Combination combination;
 
@@ -117,7 +111,7 @@ abstract class CardState extends Equatable {
 
   @override
   String toString() {
-    return "CardState($master-$combination-$mode-$lastReviewed-$interval)";
+    return 'CardState($master-$combination-$mode-$lastReviewed-$interval)';
   }
 
   @override

--- a/test/addReview_test.dart
+++ b/test/addReview_test.dart
@@ -2,9 +2,9 @@ import 'dart:math' as math;
 
 import 'package:dolphinsr_dart/src/models.dart';
 import 'package:dolphinsr_dart/src/utils.dart';
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
-import "dates.dart";
+import 'dates.dart';
 
 final String master = generateId();
 
@@ -31,34 +31,33 @@ final List<Review> reviews = [
 ].map(makeReview).toList();
 
 void main() {
-  test("should add a review to an empty list", () {
+  test('should add a review to an empty list', () {
     var reviewAdded = addReview([], reviews[0]);
     expect(reviewAdded, equals([reviews[0]]));
   });
 
-  test("should add a later review after a earlier review", () {
+  test('should add a later review after a earlier review', () {
     var reviewAdded = addReview([reviews[0]], reviews[1]);
     expect(reviewAdded, equals([reviews[0], reviews[1]]));
   });
 
-  test("should add an earlier review before a later review", () {
+  test('should add an earlier review before a later review', () {
     var reviewAdded = addReview([reviews[1]], reviews[0]);
     expect(reviewAdded, equals([reviews[0], reviews[1]]));
   });
 
-  test("should add an earlier review before a couple later reviews", () {
+  test('should add an earlier review before a couple later reviews', () {
     var reviewAdded = addReview(reviews.sublist(1), reviews[0]);
     expect(reviewAdded, equals(reviews));
   });
 
-  test("should add a review in between reviews", () {
-    var reviewAdded = addReview(
-        [reviews[0], reviews[1], reviews[2], reviews[4], reviews[5]],
-        reviews[3]);
+  test('should add a review in between reviews', () {
+    var reviewAdded =
+        addReview([reviews[0], reviews[1], reviews[2], reviews[4], reviews[5]], reviews[3]);
     expect(reviewAdded, equals(reviews));
   });
 
-  test("should add an unidentical review with a same timestamp after", () {
+  test('should add an unidentical review with a same timestamp after', () {
     Review r = makeReview(today);
     Review s = makeReview(today, rating: Rating.Again);
 

--- a/test/applyReview_test.dart
+++ b/test/applyReview_test.dart
@@ -29,97 +29,74 @@ final List<Review> reviews = [
 ].map(makeReview).toList();
 
 void main() {
-  test("should add a review to an empty list", () {
+  test('should add a review to an empty list', () {
     DRState state = makeEmptyState();
     String id = generateId();
     Combination combination = Combination(front: [], back: []);
-    Review review = Review(
-        master: id, combination: combination, ts: today, rating: Rating.Easy);
+    Review review = Review(master: id, combination: combination, ts: today, rating: Rating.Easy);
 
-    expect(() => applyReview(state, review), throwsA(startsWith("appl")));
+    expect(() => applyReview(state, review), throwsA(startsWith('appl')));
   });
 
-  test(
-      "should error if adding a review to a state with a lastReviewed later than the review",
-      () {
+  test('should error if adding a review to a state with a lastReviewed later than the review', () {
     DRState state = makeEmptyState();
     String id = generateId();
     Combination combination = Combination(front: [0], back: [1]);
 
     CardId cardId = CardId(master: id, combination: combination);
-    state.cardStates[cardId.uniqueId] =
-        makeInitialCardState(id: id, combination: combination);
+    state.cardStates[cardId.uniqueId] = makeInitialCardState(id: id, combination: combination);
 
-    Review reviewLater = Review(
-        master: id,
-        combination: combination,
-        ts: laterToday,
-        rating: Rating.Easy);
-    Review reviewToday = Review(
-        master: id, combination: combination, ts: today, rating: Rating.Easy);
+    Review reviewLater =
+        Review(master: id, combination: combination, ts: laterToday, rating: Rating.Easy);
+    Review reviewToday =
+        Review(master: id, combination: combination, ts: today, rating: Rating.Easy);
 
     DRState newState = applyReview(state, reviewLater);
 
     applyReview(state, reviewToday);
 
     expect(() => applyReview(newState, reviewToday),
-        throwsA(startsWith("Cannot apply review before current lastReviewed")));
+        throwsA(startsWith('Cannot apply review before current lastReviewed')));
   });
 
   test(
-      "should return a new state reflecting the rating when adding a review to a state with the given master and combination",
+      'should return a new state reflecting the rating when adding a review to a state with the given master and combination',
       () {
     DRState state = makeEmptyState();
     String id = generateId();
     Combination combination = Combination(front: [0], back: [1]);
 
     CardId cardId = CardId(master: id, combination: combination);
-    state.cardStates[cardId.uniqueId] =
-        makeInitialCardState(id: id, combination: combination);
+    state.cardStates[cardId.uniqueId] = makeInitialCardState(id: id, combination: combination);
 
-    Review review = Review(
-        master: id, combination: combination, ts: today, rating: Rating.Good);
+    Review review = Review(master: id, combination: combination, ts: today, rating: Rating.Good);
 
     DRState newState = applyReview(state, review);
     LearningCardState learningCardStateAfterApply = LearningCardState(
-        master: id,
-        combination: combination,
-        consecutiveCorrect: 1,
-        lastReviewed: today);
-    expect(newState.cardStates[cardId.uniqueId],
-        equals(learningCardStateAfterApply));
+        master: id, combination: combination, consecutiveCorrect: 1, lastReviewed: today);
+    expect(newState.cardStates[cardId.uniqueId], equals(learningCardStateAfterApply));
   });
 
-  test(
-      "should accurately navigate through learning, reviewing, and lapsed modes",
-      () {
+  test('should accurately navigate through learning, reviewing, and lapsed modes', () {
     DRState state = makeEmptyState();
     String id = generateId();
     Combination combination = Combination(front: [0], back: [1]);
 
     CardId cardId = CardId(master: id, combination: combination);
-    state.cardStates[cardId.uniqueId] =
-        makeInitialCardState(id: id, combination: combination);
+    state.cardStates[cardId.uniqueId] = makeInitialCardState(id: id, combination: combination);
 
-    Review review = Review(
-        master: id, combination: combination, ts: today, rating: Rating.Good);
+    Review review = Review(master: id, combination: combination, ts: today, rating: Rating.Good);
 
     DRState stateB = applyReview(state, review);
 
     LearningCardState learningCardStateAfterApply = LearningCardState(
-        master: id,
-        combination: combination,
-        consecutiveCorrect: 1,
-        lastReviewed: today);
+        master: id, combination: combination, consecutiveCorrect: 1, lastReviewed: today);
 
     LearningCardState processedCard = stateB.cardStates[cardId.uniqueId];
     expect(processedCard, equals(learningCardStateAfterApply));
 
-    Review reviewC = Review(
-        master: id,
-        combination: combination,
-        ts: laterToday,
-        rating: Rating.Easy);
+    Review reviewC =
+        Review(master: id, combination: combination, ts: laterToday, rating: Rating.Easy);
 
     DRState stateC = applyReview(stateB, reviewC);
 
@@ -141,11 +118,8 @@ void main() {
     datePlusFour = datePlusFour.add(Duration(days: 4));
     expect(stateCDue, equals(datePlusFour));
 
-    Review reviewD = Review(
-        master: id,
-        combination: combination,
-        ts: stateCDue,
-        rating: Rating.Easy);
+    Review reviewD =
+        Review(master: id, combination: combination, ts: stateCDue, rating: Rating.Easy);
     DRState stateD = applyReview(stateC, reviewD);
     ReviewingCardState learningCardStateAfterApplyD = ReviewingCardState(
         master: id,
@@ -155,16 +129,12 @@ void main() {
         factor: 2650,
         interval: 20);
 
-    expect(stateD.cardStates[cardId.uniqueId],
-        equals(learningCardStateAfterApplyD));
+    expect(stateD.cardStates[cardId.uniqueId], equals(learningCardStateAfterApplyD));
 
     DateTime stateDDue = calculateDueDate(stateD.cardStates[cardId.uniqueId]);
 
-    Review reviewE = Review(
-        master: id,
-        combination: combination,
-        ts: stateDDue,
-        rating: Rating.Again);
+    Review reviewE =
+        Review(master: id, combination: combination, ts: stateDDue, rating: Rating.Again);
     DRState stateE = applyReview(stateD, reviewE);
 
     LapsedCardState learningCardStateAfterApplyE = LapsedCardState(
@@ -176,15 +146,11 @@ void main() {
         factor: 2450,
         interval: 20);
 
-    expect(stateE.cardStates[cardId.uniqueId],
-        equals(learningCardStateAfterApplyE));
+    expect(stateE.cardStates[cardId.uniqueId], equals(learningCardStateAfterApplyE));
 
     DateTime reviewDateE = stateDDue.add(Duration(days: 1));
-    Review reviewF = Review(
-        master: id,
-        combination: combination,
-        ts: reviewDateE,
-        rating: Rating.Again);
+    Review reviewF =
+        Review(master: id, combination: combination, ts: reviewDateE, rating: Rating.Again);
     DRState stateF = applyReview(stateE, reviewF);
 
     LapsedCardState learningCardStateAfterApplyF = LapsedCardState(
@@ -195,15 +161,11 @@ void main() {
         lastReviewed: reviewDateE,
         factor: 2450,
         interval: 20);
-    expect(stateF.cardStates[cardId.uniqueId],
-        equals(learningCardStateAfterApplyF));
+    expect(stateF.cardStates[cardId.uniqueId], equals(learningCardStateAfterApplyF));
 
     DateTime reviewDateG = stateDDue.add(Duration(days: 1));
-    Review reviewG = Review(
-        master: id,
-        combination: combination,
-        ts: reviewDateG,
-        rating: Rating.Easy);
+    Review reviewG =
+        Review(master: id, combination: combination, ts: reviewDateG, rating: Rating.Easy);
     DRState stateG = applyReview(stateF, reviewG);
 
     ReviewingCardState learningCardStateAfterApplyG = ReviewingCardState(
@@ -213,7 +175,6 @@ void main() {
         lastReviewed: reviewDateG,
         factor: 2450,
         interval: 1);
-    expect(stateG.cardStates[cardId.uniqueId],
-        equals(learningCardStateAfterApplyG));
+    expect(stateG.cardStates[cardId.uniqueId], equals(learningCardStateAfterApplyG));
   });
 }

--- a/test/computeCardsSchedule_test.dart
+++ b/test/computeCardsSchedule_test.dart
@@ -1,9 +1,9 @@
 import 'dart:math' as math;
 import 'package:dolphinsr_dart/src/models.dart';
 import 'package:dolphinsr_dart/src/utils.dart';
-import "package:test/test.dart";
+import 'package:test/test.dart';
 
-import "dates.dart";
+import 'dates.dart';
 
 final master = generateId();
 
@@ -30,7 +30,7 @@ final List<Review> reviews = [
 ].map(makeReview).toList();
 
 void main() {
-  test("should add a rounded interval to the lastReviewed, set at 3am", () {
+  test('should add a rounded interval to the lastReviewed, set at 3am', () {
     String id = generateId();
     Combination combination = Combination(front: [0], back: [1]);
     ReviewingCardState stateCard = ReviewingCardState(
@@ -46,7 +46,7 @@ void main() {
     DateTime expectedDate = todayAt3AM.add(Duration(days: 14));
     expect(due, equals(expectedDate));
   });
-  test("should return later for cards that are reviewing and not yet due", () {
+  test('should return later for cards that are reviewing and not yet due', () {
     String id = generateId();
     Combination combination = Combination(front: [0], back: [1]);
 
@@ -60,11 +60,10 @@ void main() {
 
     String computeSchedule = computeScheduleFromCardState(stateCard, laterTmrw);
 
-    expect(computeSchedule, equals("later"));
+    expect(computeSchedule, equals('later'));
   });
 
-  test("should return due for cards that are reviewing and due within the day",
-      () {
+  test('should return due for cards that are reviewing and due within the day', () {
     String id = generateId();
     Combination combination = Combination(front: [0], back: [1]);
 
@@ -76,18 +75,16 @@ void main() {
         factor: 1000,
         interval: 13.3);
 
-    String computeSchedule = computeScheduleFromCardState(
-        stateCard, todayAt3AM.add(Duration(days: 14)));
+    String computeSchedule =
+        computeScheduleFromCardState(stateCard, todayAt3AM.add(Duration(days: 14)));
 
-    expect(computeSchedule, equals("due"));
+    expect(computeSchedule, equals('due'));
 
-    computeSchedule = computeScheduleFromCardState(
-        stateCard, laterToday.add(Duration(days: 14)));
-    expect(computeSchedule, equals("due"));
+    computeSchedule = computeScheduleFromCardState(stateCard, laterToday.add(Duration(days: 14)));
+    expect(computeSchedule, equals('due'));
   });
 
-  test("should return overdue for cards that reviewing and due before the day",
-      () {
+  test('should return overdue for cards that reviewing and due before the day', () {
     String id = generateId();
     Combination combination = Combination(front: [0], back: [1]);
 
@@ -99,17 +96,16 @@ void main() {
         factor: 1000,
         interval: 13.3);
 
-    String computeSchedule = computeScheduleFromCardState(
-        stateCard, todayAt3AM.add(Duration(days: 15)));
+    String computeSchedule =
+        computeScheduleFromCardState(stateCard, todayAt3AM.add(Duration(days: 15)));
 
-    expect(computeSchedule, equals("overdue"));
+    expect(computeSchedule, equals('overdue'));
 
-    computeSchedule = computeScheduleFromCardState(
-        stateCard, laterToday.add(Duration(days: 15)));
-    expect(computeSchedule, equals("overdue"));
+    computeSchedule = computeScheduleFromCardState(stateCard, laterToday.add(Duration(days: 15)));
+    expect(computeSchedule, equals('overdue'));
   });
 
-  test("should return an empty schedule when passed an empty state", () {
+  test('should return an empty schedule when passed an empty state', () {
     DRState emptyState = makeEmptyState();
 
     expect(computeCardsSchedule(emptyState, today).learning.length, equals(0));
@@ -118,8 +114,7 @@ void main() {
     expect(computeCardsSchedule(emptyState, today).overdue.length, equals(0));
   });
 
-  test("should a sorted list of cards when passed cards in multiple states",
-      () {
+  test('should a sorted list of cards when passed cards in multiple states', () {
     DRState emptyState = makeEmptyState();
 
     String id = generateId();
@@ -178,8 +173,7 @@ void main() {
     expect(s.overdue[0].uniqueId, equals(getCardIdFromCardState(overDue)));
   });
 
-  test("PickMostDue should return null when passed an empty schedule and state",
-      () {
+  test('PickMostDue should return null when passed an empty schedule and state', () {
     DRState emptyState = makeEmptyState();
     CardsSchedule s = computeCardsSchedule(emptyState, today);
     final pick = pickMostDue(s, emptyState);
@@ -187,7 +181,7 @@ void main() {
   });
 
   test(
-      "PickMostDue should return the learning card reviewed most recently if two learning cards are in the deck",
+      'PickMostDue should return the learning card reviewed most recently if two learning cards are in the deck',
       () {
     DRState emptyState = makeEmptyState();
 

--- a/test/dolphinsr_dart_test.dart
+++ b/test/dolphinsr_dart_test.dart
@@ -1,8 +1,8 @@
 import 'dart:math' as math;
 import 'package:dolphinsr_dart/dolphinsr_dart.dart';
 import 'package:dolphinsr_dart/src/models.dart';
-import "package:test/test.dart";
-import "dates.dart";
+import 'package:test/test.dart';
+import 'dates.dart';
 
 final String master = generateId();
 
@@ -29,21 +29,20 @@ final List<Review> reviews = <DateTime>[
 ].map(makeReview).toList();
 
 void main() {
-  test("should start out empty", () {
+  test('should start out empty', () {
     final DolphinSR d = DolphinSR();
     expect(d.nextCard(), isNull);
 
-    SummaryStatics s =
-        const SummaryStatics(later: 0, due: 0, overdue: 0, learning: 0);
+    SummaryStatics s = const SummaryStatics(later: 0, due: 0, overdue: 0, learning: 0);
     expect(d.summary(), equals(s));
   });
 
-  test("should add a new masters to the learning", () {
+  test('should add a new masters to the learning', () {
     DolphinSR d = DolphinSR();
     String id = generateId();
     Master master = Master(id: id, fields: [
       'Hello',
-      "world"
+      'world'
     ], combinations: [
       Combination(front: [0], back: [1, 0])
     ]);
@@ -54,17 +53,17 @@ void main() {
     DRCard expectedCard = DRCard(
         master: id,
         combination: Combination(front: [0], back: [1, 0]),
-        front: ["Hello"],
-        back: ["world", "Hello"]);
+        front: ['Hello'],
+        back: ['world', 'Hello']);
     expect(nextCard, equals(expectedCard));
   });
 
-  test("should add multiple new masters to the learning category", () {
+  test('should add multiple new masters to the learning category', () {
     DolphinSR d = DolphinSR();
     String id = generateId();
     Master master = Master(id: id, fields: [
       'Hello',
-      "world"
+      'world'
     ], combinations: [
       Combination(front: [0], back: [1, 0])
     ]);
@@ -72,22 +71,21 @@ void main() {
 
     Master master2 = Master(id: id2, fields: [
       'Hello',
-      "world"
+      'world'
     ], combinations: [
       Combination(front: [0], back: [1, 0])
     ]);
 
     d.addMasters([master, master2]);
 
-    SummaryStatics s =
-        SummaryStatics(later: 0, due: 0, overdue: 0, learning: 2);
+    SummaryStatics s = SummaryStatics(later: 0, due: 0, overdue: 0, learning: 2);
     expect(d.summary(), equals(s));
 
     String id3 = generateId();
 
     Master master3 = Master(id: id3, fields: [
       'Hello',
-      "world"
+      'world'
     ], combinations: [
       Combination(front: [0], back: [1, 0])
     ]);
@@ -97,12 +95,11 @@ void main() {
     expect(d.summary(), equals(s));
   });
 
-  test("should add reviews", () {
+  test('should add reviews', () {
     DolphinSR d = DolphinSR(currentDateGetter: today);
     String id = generateId();
     Combination combination = Combination(front: [0], back: [1, 0]);
-    Master master =
-        Master(id: id, fields: ['Hello', "world"], combinations: [combination]);
+    Master master = Master(id: id, fields: ['Hello', 'world'], combinations: [combination]);
 
     d.addMasters([master]);
 
@@ -110,22 +107,19 @@ void main() {
     DRCard expectedCard = DRCard(
         master: id,
         combination: Combination(front: [0], back: [1, 0]),
-        front: ["Hello"],
-        back: ["world", "Hello"]);
+        front: ['Hello'],
+        back: ['world', 'Hello']);
     expect(nextCard, equals(expectedCard));
     expect(d.summary().learning, equals(1));
 
-    Review review = Review(
-        master: id, combination: combination, ts: today, rating: Rating.Easy);
+    Review review = Review(master: id, combination: combination, ts: today, rating: Rating.Easy);
     d.addReviews([review]);
 
     expect(d.summary().later, equals(1));
     expect(d.nextCard(), isNull);
 
-    Master secondMaster = Master(
-        id: generateId(),
-        fields: ['Hello', "world"],
-        combinations: [combination]);
+    Master secondMaster =
+        Master(id: generateId(), fields: ['Hello', 'world'], combinations: [combination]);
     d.addMasters([secondMaster]);
     expect(d.summary().learning, equals(1));
     expect(d.summary().later, equals(1));
@@ -140,11 +134,11 @@ void main() {
     expect(d.nextCard(), isNull);
   });
 
-  /* test("Will it works ? ", () {
+  /* test('Will it works ? ', () {
     DolphinSR d = DolphinSR(currentDateGetter: Dates.today);
     String id = generateId();
     Combination combination = Combination([0], [1, 0]);
-    Master master = Master(id, ['Hello', "world"], [combination]);
+    Master master = Master(id, ['Hello', 'world'], [combination]);
 
     d.addMasters([master]);
 
@@ -152,8 +146,8 @@ void main() {
     Card expectedCard = Card(
         master: id,
         combination: Combination([0], [1, 0]),
-        front: ["Hello"],
-        back: ["world", "Hello"]);
+        front: ['Hello'],
+        back: ['world', 'Hello']);
     expect(nextCard, equals(expectedCard));
     expect(d.summary().learning, equals(1));
 


### PR DESCRIPTION
Fixed warnings for linter prefer_single_quotes rule by replacing double quotes by simple one's 